### PR TITLE
fixed booking image height

### DIFF
--- a/app/assets/stylesheets/components/_booking_cards.scss
+++ b/app/assets/stylesheets/components/_booking_cards.scss
@@ -11,9 +11,11 @@
 }
 
 .card-booking img {
-  height: 100%;
+  height: 180px;
   width: 170px;
-  object-fit: cover;
+  object-fit: contain !important;
+  margin-left: 8px;
+  border-radius: 10%;
 }
 
 .card-booking .card-booking-infos {


### PR DESCRIPTION
Fixed container object cover and added margin for photos with background
<img width="750" alt="Screen Shot 2020-05-20 at 5 27 39 PM" src="https://user-images.githubusercontent.com/61980510/82465133-35c8bb00-9abf-11ea-9c34-f1f1c9badab4.png">
